### PR TITLE
Pin to PHP7.3 and Alpine 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM alpine:3
+FROM alpine:3.12
+
 ARG wallabag_version=2.3.8
 
 RUN apk upgrade --no-cache && apk add --no-cache \


### PR DESCRIPTION
Alpine 3.13 brings in PHP 7.4, but Wallabag 2.3 is not compatible with it and
fails with this error:

> PHP Fatal error:  Cannot redeclare mb_str_split() in
> /var/www/wallabag/vendor/wallabag/php-mobi/MOBIClass/RecordFactory.php on line
> 119

Should update to Wallabag 2.4 which is PHP 7.4 compatible.
